### PR TITLE
Reduce the lenght of the pathname

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM scratch
 MAINTAINER Nathan Osman <nathan@quickmediasolutions.com>
 
 # Add the binary to the container
-ADD hang /usr/bin/hang
+ADD hang /hang
 
 # Set it as the default entrypoint
-ENTRYPOINT ["/usr/bin/hang"]
+ENTRYPOINT ["/hang"]


### PR DESCRIPTION
This saves a few more characters that will be saved in the docker metadata.
Not much, but shaving a few more bytes seems in the spirit of this project.