### PR TITLE
Use multi-stage build to generate the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
+FROM nathanosman/nasm as builder
+ADD hang.asm /hang.asm
+RUN nasm -f elf64 hang.asm
+RUN ld -s -o hang hang.o
+
+
 FROM scratch
 MAINTAINER Nathan Osman <nathan@quickmediasolutions.com>
 
 # Add the binary to the container
-ADD hang /hang
+COPY --from=builder /hang /hang
 
 # Set it as the default entrypoint
 ENTRYPOINT ["/hang"]


### PR DESCRIPTION
Use two stages, one to build the binary and copy in the other the
compiled binary.