### PR TITLE
Use shorter opcodes for instructions

### DIFF
--- a/hang.asm
+++ b/hang.asm
@@ -110,7 +110,6 @@ restorer:
     mov al, sys_rt_sigreturn
     syscall
 
-align 16 ; 1 byte nop 
 error:
 
     ; Display an error message
@@ -119,4 +118,5 @@ error:
     lea esi, [rbp-(act-error_msg)] ;offset to error_msg from act
     lea edx, [rax+error_msg_len]
     mov al, sys_write
+    syscall
     jmp exit

--- a/hang.asm
+++ b/hang.asm
@@ -99,7 +99,6 @@ handler:
     lea edx, [rax+sigterm_msg_len]
     mov al, sys_write
     mov edi, eax ; set edi=1 STDOUT
-;    mov al, sys_write 
     syscall
 
     ret

--- a/hang.asm
+++ b/hang.asm
@@ -19,7 +19,7 @@
 ; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 ; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 ; SOFTWARE.
-
+%use smartalign
 %define sys_write        0x01
 %define sys_rt_sigaction 0x0d
 %define sys_rt_sigreturn 0x0f
@@ -95,10 +95,11 @@ handler:
 
     ; Display a message
     xor eax, eax
-    lea edi, [rax+STDOUT]
     lea esi, [rbp-(act-sigterm_msg)] ; offset to sigterm_msg from act
     lea edx, [rax+sigterm_msg_len]
     mov al, sys_write
+    mov edi, eax ; set edi=1 STDOUT
+;    mov al, sys_write 
     syscall
 
     ret
@@ -110,13 +111,14 @@ restorer:
     mov al, sys_rt_sigreturn
     syscall
 
+    align 16
 error:
 
     ; Display an error message
     xor eax, eax
-    lea edi, [rax+STDOUT]
     lea esi, [rbp-(act-error_msg)] ;offset to error_msg from act
     lea edx, [rax+error_msg_len]
     mov al, sys_write
+    mov edi, eax; edi=1 STDOUT
     syscall
     jmp exit


### PR DESCRIPTION
I've changed the instructions to use 32bit registers as they're enough. Also save the return value in a register so we don't need a .bss section 